### PR TITLE
Add prefered Language as fallback language

### DIFF
--- a/src/Service/Translator.php
+++ b/src/Service/Translator.php
@@ -48,7 +48,7 @@ class Translator
      * @param null $locale
      * @return string
      */
-    public function translate($string, array $parameters = [], $domain = null, $locale = null)
+    public function translate($string, array $parameters = [], $domain = null, $locale = null): string
     {
         if (!$locale) {
             $locale = $this->loadCurrentLocale();
@@ -60,7 +60,7 @@ class Translator
     /**
      * @return mixed|string
      */
-    public function loadCurrentLocale()
+    public function loadCurrentLocale(): string
     {
         $request = $this->requestStack->getCurrentRequest();
 
@@ -71,7 +71,9 @@ class Translator
         $localeCode = $request->query->get('locale');
 
         if (!$localeCode) {
-            return $this->defaultLocale;
+            $preferredLanguage = $request->getPreferredLanguage();
+
+            return empty($preferredLanguage) ? $this->defaultLocale : $preferredLanguage;
         }
 
         return $localeCode;

--- a/tests/Service/TranslatorTest.php
+++ b/tests/Service/TranslatorTest.php
@@ -115,6 +115,36 @@ class TranslatorTest extends TestCase
 
     /**
      * @test loadCurrentLocale
+     * @dataProvider provideLocalesWithAcceptLanguage
+     */
+    public function testLoadAcceptedLanguagesHeader(
+        $requestedLocale,
+        $acceptedLanguage,
+        $expectedLocale
+    ) {
+        $translator = new Translator($this->translator, $this->requestStack, $this->defaultLocale);
+
+        $request = $this->createConfiguredMock(Request::class, [
+            'getPreferredLanguage' => $acceptedLanguage
+        ]);
+        $request->query = $this->createMock(ParameterBag::class);
+        $this->requestStack
+            ->expects($this->once())
+            ->method('getCurrentRequest')
+            ->willReturn($request);
+
+        $request->query
+            ->expects($this->once())
+            ->method('get')
+            ->with('locale')
+            ->willReturn($requestedLocale);
+
+        $actualLocale = $translator->loadCurrentLocale();
+        $this->assertSame($expectedLocale, $actualLocale);
+    }
+
+    /**
+     * @test loadCurrentLocale
      */
     public function testLoadCurrentLocaleWithNoRequest()
     {
@@ -166,5 +196,20 @@ class TranslatorTest extends TestCase
         yield['hr', 'hr'];
         yield['', 'en'];
         yield[null, 'en'];
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function provideLocalesWithAcceptLanguage()
+    {
+        yield['en', 'fr', 'en'];
+        yield['hr', 'de', 'hr'];
+        yield['', 'fr', 'fr'];
+        yield['de', '', 'de'];
+        yield[null, 'it', 'it'];
+        yield['nl', null, 'nl'];
+        yield['', '', 'en'];
+        yield[null, null, 'en'];
     }
 }


### PR DESCRIPTION
Hello,

For respect to [RFC 7231 section 5.3.5](https://tools.ietf.org/html/rfc7231#section-5.3.5), we can use the header `Accept-Language` Header to fallback to preferred language of user.

Into Symfony all is available by `$request->getPreferredLanguage()`

Thanks