### PR TITLE
Translation has not key with locale

### DIFF
--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Locastic\ApiPlatformTranslationBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Expr\Comparison;
 use Doctrine\ORM\PersistentCollection;
 
 /**
@@ -68,8 +70,10 @@ trait TranslatableTrait
             return $this->translationsCache[$locale];
         }
 
-        $translation = $this->translations->get($locale);
-        if (null !== $translation) {
+        $expr = new Comparison('locale', '=', $locale);
+        $translation = $this->translations->matching(new Criteria($expr))->first();
+
+        if (false !== $translation) {
             $this->translationsCache[$locale] = $translation;
 
             return $translation;
@@ -79,9 +83,10 @@ trait TranslatableTrait
                 return $this->translationsCache[$this->fallbackLocale];
             }
 
-            $fallbackTranslation = $this->translations->get($this->fallbackLocale);
+            $expr = new Comparison('locale', '=', $this->fallbackLocale);
+            $fallbackTranslation = $this->translations->matching(new Criteria($expr))->first();
 
-            if (null !== $fallbackTranslation) {
+            if (false !== $fallbackTranslation) {
                 $this->translationsCache[$this->fallbackLocale] = $fallbackTranslation; //@codeCoverageIgnore
 
                 return $fallbackTranslation; //@codeCoverageIgnore


### PR DESCRIPTION
Currently the code use the key of ArrayCollection to find the good item.
That's make by the add method which add the good key

But doctrine when it load from database, not use the getter/setter
![image](https://user-images.githubusercontent.com/472429/61900420-ddb43d00-af1d-11e9-9e80-dc3312a294d2.png)
https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/working-with-objects.html

So i make change to search into array of translation
