### PR TITLE
Add fallback with default_locale from Symfony

### DIFF
--- a/src/EventListener/AssignLocaleListener.php
+++ b/src/EventListener/AssignLocaleListener.php
@@ -21,13 +21,20 @@ class AssignLocaleListener
     private $translator;
 
     /**
+     * @var string
+     */
+    private $defaultLocale;
+
+    /**
      * AssignLocaleListener constructor.
      *
      * @param Translator $translator
+     * @param string $defaultLocale
      */
-    public function __construct(Translator $translator)
+    public function __construct(Translator $translator, string $defaultLocale = 'en')
     {
         $this->translator = $translator;
+        $this->defaultLocale = $defaultLocale;
     }
 
     /**
@@ -60,6 +67,6 @@ class AssignLocaleListener
         $localeCode = $this->translator->loadCurrentLocale();
 
         $object->setCurrentLocale($localeCode);
-        $object->setFallbackLocale($localeCode);
+        $object->setFallbackLocale($this->defaultLocale);
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -10,6 +10,7 @@ services:
         class: Locastic\ApiPlatformTranslationBundle\EventListener\AssignLocaleListener
         arguments:
             - '@locastic_api_platform_translation.translation.translator'
+            - '%kernel.default_locale%'
         tags:
             - { name: doctrine.event_listener, event: postLoad }
             - { name: doctrine.event_listener, event: prePersist }


### PR DESCRIPTION
Hello,

Currently the locale setted and the fallbacklocale is the same.
I set the fallback with default_locale from Symfony

I set a default arg into constructor to no add BC