### PR TITLE
Document usage of accept language header

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Usage:
 
 `?locale=de`
 
+**Or use Accept-Language http header**
+
+`Accept-Language: de`
+
 **Serialization group for displaying all translations:** 
 
 `?groups[]=translations`


### PR DESCRIPTION
It's currently possible to choose the language with the `Accept-Language` header thanks to `Request::getPreferredLanguage()` but this is not documented yet and we have to look inside the code to see this.

This PR aims to fix that