### PR TITLE
Update composer.json and fix parameter usage in services.yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "locastic/api-platform-translation-bundle",
   "description": "Translation bundle for Api platform based on Sylius translation",
   "license": "MIT",
+  "type": "symfony-bundle",
   "authors": [
     {
       "name": "Paula",

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -4,7 +4,7 @@ services:
         arguments:
             - '@translator'
             - '@request_stack'
-            - '%locale%'
+            - '%kernel.default_locale%'
 
     locastic_api_platform_translation.listener.assign_locale:
         class: Locastic\ApiPlatformTranslationBundle\EventListener\AssignLocaleListener


### PR DESCRIPTION
Hi, first of all great bundle, I really like how it works! While setting it up on a new project, I've noticed what I think are 2 typos.

1) composer.json is missing the "type": "symfony-bundle" tag, and that prevents Symfony from registering the bundle automatically
2) There is a %locale% parameter that is used instead of the %kernel.default_locale% parameter in services.yml. This parameter forced me to define a `locale` parameter with the same value as `default_locale` in framework.yml. I've edited services.yml to use `kernel.default_locale` always.

I've created a single PR, but if you want I can create 2 of them, let me know your comments!