### PR TITLE
Bug: fix conflicts with symfony/translations-contracts <2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
   },
   "config": {
     "bin-dir": "bin"
+  },
+  "conflict": {
+    "symfony/translations-contracts": "<2.0"
   }
 }


### PR DESCRIPTION
Uptading Locastic 1.3.2
<2.0 symfony/translations-contracts::trans isn't compatible with locastic/ApiPlatformTranslationBundle::trans because of the $domain and $locale typehint.

symfony/translations-contracts::trans($id, array $parameters = [], $domain = null, $locale = null);
locastic/ApiPlatformTranslationBundle::trans($id, array $parameters = array(), string $domain = null, string $locale = null): string