### PR TITLE
Declare group filter whitelist to prevent exposure of prohibited properties

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -18,5 +18,9 @@ services:
 # Filters
     locastic_api_platform_translation.filter.translation_groups:
         parent: 'api_platform.serializer.group_filter'
+        arguments:
+            - 'groups'
+            - false
+            - ['translations']
         tags:
             - { name: 'api_platform.filter', id: 'translation.groups' }


### PR DESCRIPTION
## Description
If `translation.groups` is defined as filter without a defined whitelist, it will allow to provide just any serialization group for the `?groups[]=` parameter.
This might expose properties with serialization groups that are not defined in the `normalizationContext` of an API resource and shouldn't be exposed.

By configuring `locastic_api_platform_translation.filter.translation_groups` arguments with `'translations'` defined in the `$whitelist` parameter, only the `translations` serialization group is allowed for the filter defined by this bundle. 

