### PR TITLE
Removal setting default translation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
->
+         bootstrap="vendor/autoload.php">
+    <coverage>
+        <include>
+            <directory>./src/</directory>
+        </include>
+        <exclude>
+            <directory>./vendor/</directory>
+            <directory>./tests/</directory>
+        </exclude>
+    </coverage>
     <php>
-        <ini name="error_reporting" value="-1" />
+        <ini name="error_reporting" value="-1"/>
         <!-- define your env variables for the test env here -->
     </php>
-
     <testsuites>
         <testsuite name="LocasticApiPlatformTranslation Test Suite">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./src/</directory>
-            <exclude>
-                <directory>./vendor/</directory>
-                <directory>./tests/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/ApiPlatformTranslationBundle.php
+++ b/src/ApiPlatformTranslationBundle.php
@@ -5,8 +5,6 @@ namespace Locastic\ApiPlatformTranslationBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
- * Class ApiPlatformTranslationBundle
- *
  * @package Locastic\ApiPlatformTranslationBundle
  */
 class ApiPlatformTranslationBundle extends Bundle

--- a/src/DependencyInjection/ApiPlatformTranslationExtension.php
+++ b/src/DependencyInjection/ApiPlatformTranslationExtension.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Locastic\ApiPlatformTranslationBundle\DependencyInjection;
 
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * This is the class that loads and manages your bundle configuration
@@ -21,13 +21,13 @@ class ApiPlatformTranslationExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $directory =
+            __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'config';
+
+        $loader = new Loader\YamlFileLoader($container, new FileLocator($directory));
         $loader->load('services.yml');
     }
 
-    /**
-     * @return string
-     */
     public function getAlias(): string
     {
         return 'api_platform_translation';

--- a/src/EventListener/AssignLocaleListener.php
+++ b/src/EventListener/AssignLocaleListener.php
@@ -9,26 +9,14 @@ use Locastic\ApiPlatformTranslationBundle\Model\TranslatableInterface;
 use Locastic\ApiPlatformTranslationBundle\Translation\Translator;
 
 /**
- * Class AssignLocaleListener
- *
  * @package Locastic\ApiPlatformTranslationBundle\EventListener
  */
 class AssignLocaleListener
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
-
-    /**
-     * @var string
-     */
-    private $defaultLocale;
-
-    public function __construct(Translator $translator, string $defaultLocale = 'en')
-    {
-        $this->translator = $translator;
-        $this->defaultLocale = $defaultLocale;
+    public function __construct(
+        private Translator $translator,
+        private string $defaultLocale = 'en'
+    ) {
     }
 
     public function postLoad(EventArgs $args): void

--- a/src/Model/AbstractTranslatable.php
+++ b/src/Model/AbstractTranslatable.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Locastic\ApiPlatformTranslationBundle\Model;
 
 /**
- * Class AbstractTranslatable
- *
  * @package Locastic\ApiPlatformTranslationBundle\Model
  */
 abstract class AbstractTranslatable implements TranslatableInterface
@@ -16,7 +14,6 @@ abstract class AbstractTranslatable implements TranslatableInterface
     }
 
     /**
-     * AbstractTranslatable constructor.
      * @codeCoverageIgnore
      */
     public function __construct()

--- a/src/Model/AbstractTranslation.php
+++ b/src/Model/AbstractTranslation.php
@@ -9,12 +9,12 @@ namespace Locastic\ApiPlatformTranslationBundle\Model;
  *
  * @package Locastic\ApiPlatformTranslationBundle\Model
  */
-class AbstractTranslation implements TranslationInterface
+abstract class AbstractTranslation implements TranslationInterface
 {
     private ?TranslatableInterface $translatable = null;
 
     public function __construct(
-        private string $locale,
+        protected string $locale,
         ?TranslatableInterface $translatable
     ) {
         $this->setTranslatable($translatable);

--- a/src/Model/AbstractTranslation.php
+++ b/src/Model/AbstractTranslation.php
@@ -14,7 +14,7 @@ class AbstractTranslation implements TranslationInterface
     private ?TranslatableInterface $translatable = null;
 
     public function __construct(
-        private ?string $locale,
+        private string $locale,
         ?TranslatableInterface $translatable
     ) {
         $this->setTranslatable($translatable);

--- a/src/Model/AbstractTranslation.php
+++ b/src/Model/AbstractTranslation.php
@@ -11,18 +11,16 @@ namespace Locastic\ApiPlatformTranslationBundle\Model;
  */
 class AbstractTranslation implements TranslationInterface
 {
-    /**
-     * @var null|string
-     */
-    protected $locale;
+    private ?TranslatableInterface $translatable = null;
+
+    public function __construct(
+        private ?string $locale,
+        ?TranslatableInterface $translatable
+    ) {
+        $this->setTranslatable($translatable);
+    }
 
     /**
-     * @var TranslatableInterface
-     */
-    protected $translatable;
-
-    /**
-     * {@inheritdoc}
      * @codeCoverageIgnore
      */
     public function getTranslatable(): ?TranslatableInterface
@@ -30,9 +28,6 @@ class AbstractTranslation implements TranslationInterface
         return $this->translatable;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setTranslatable(?TranslatableInterface $translatable): void
     {
         if ($translatable === $this->translatable) {
@@ -42,29 +37,23 @@ class AbstractTranslation implements TranslationInterface
         $previousTranslatable = $this->translatable;
         $this->translatable = $translatable;
 
-        if (null !== $previousTranslatable) {
-            $previousTranslatable->removeTranslation($this);
-        }
+        $previousTranslatable?->removeTranslation($this);
 
-        if (null !== $translatable) {
-            $translatable->addTranslation($this);
-        }
+        $translatable?->addTranslation($this);
     }
 
     /**
-     * {@inheritdoc}
      * @codeCoverageIgnore
      */
-    public function getLocale(): ?string
+    public function getLocale(): string
     {
         return $this->locale;
     }
 
     /**
-     * {@inheritdoc}
      * @codeCoverageIgnore
      */
-    public function setLocale(?string $locale): void
+    public function setLocale(string $locale): void
     {
         $this->locale = $locale;
     }

--- a/src/Model/LocaleNotSupported.php
+++ b/src/Model/LocaleNotSupported.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Locastic\ApiPlatformTranslationBundle\Model;
+
+final class LocaleNotSupported extends \RuntimeException
+{
+    public static function unsupported(): self
+    {
+        return new self('No locale was received and the current locale is not supported for translations.');
+    }
+}

--- a/src/Model/TranslatableInterface.php
+++ b/src/Model/TranslatableInterface.php
@@ -7,48 +7,21 @@ namespace Locastic\ApiPlatformTranslationBundle\Model;
 use Doctrine\Common\Collections\Collection;
 
 /**
- * Interface TranslatableInterface
- *
  * @package Locastic\ApiPlatformTranslationBundle\Model
  */
 interface TranslatableInterface
 {
     /**
-     * @return Collection<TranslationInterface>|TranslationInterface[]
+     * @return Collection<TranslationInterface>
      */
     public function getTranslations(): Collection;
 
-    /**
-     * @param null|string $locale
-     *
-     * @return TranslationInterface
-     */
     public function getTranslation(?string $locale = null): TranslationInterface;
-
-    /**
-     * @param TranslationInterface $translation
-     *
-     * @return bool
-     */
     public function hasTranslation(TranslationInterface $translation): bool;
 
-    /**
-     * @param TranslationInterface $translation
-     */
     public function addTranslation(TranslationInterface $translation): void;
-
-    /**
-     * @param TranslationInterface $translation
-     */
     public function removeTranslation(TranslationInterface $translation): void;
 
-    /**
-     * @param null|string $locale
-     */
     public function setCurrentLocale(?string $locale): void;
-
-    /**
-     * @param null|string $locale
-     */
     public function setFallbackLocale(?string $locale): void;
 }

--- a/src/Model/TranslatableInterface.php
+++ b/src/Model/TranslatableInterface.php
@@ -16,7 +16,7 @@ interface TranslatableInterface
      */
     public function getTranslations(): Collection;
 
-    public function getTranslation(?string $locale = null): TranslationInterface;
+    public function getTranslation(string $locale = null): ?TranslationInterface;
     public function hasTranslation(TranslationInterface $translation): bool;
 
     public function addTranslation(TranslationInterface $translation): void;

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -17,9 +17,10 @@ use Doctrine\Common\Collections\Expr\Comparison;
 trait TranslatableTrait
 {
     /**
+     * Protected to allow access in classes using this Trait or extending provided AbstractTranslatable
      * @var Collection<TranslationInterface>|TranslationInterface[]
      */
-    private array|Collection|ArrayCollection $translations;
+    protected array|Collection|ArrayCollection $translations;
     /**
      * @var array|TranslationInterface[]
      */
@@ -94,10 +95,9 @@ trait TranslatableTrait
      */
     public function getTranslationLocales(): array
     {
-        $translations = $this->getTranslations();
         $locales = [];
 
-        foreach ($translations as $translation) {
+        foreach ($this->getTranslations() as $translation) {
             $locales[] = $translation->getLocale();
         }
 

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -64,7 +64,7 @@ trait TranslatableTrait
         }
 
         // Check and return fallback Translation from Translatable objects' cache or attempt fallback locale match
-        return $this->translationsCache[$this->fallbackLocale] ?? $this->matchTranslation($this->fallbackLocale);
+        return $this->matchTranslation($this->fallbackLocale);
     }
 
     /**

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
-use Doctrine\ORM\PersistentCollection;
 
 /**
  * @see TranslatableInterface
@@ -20,32 +19,19 @@ trait TranslatableTrait
     /**
      * @var Collection<TranslationInterface>|TranslationInterface[]
      */
-    protected $translations;
-
+    private array|Collection|ArrayCollection $translations;
     /**
      * @var array|TranslationInterface[]
      */
-    protected $translationsCache = [];
-
-    /**
-     * @var null|string
-     */
-    protected $currentLocale;
-
+    private array $translationsCache = [];
+    private ?string $currentLocale;
     /**
      * Cache current translation. Useful in Doctrine 2.4+
-     *
-     * @var TranslationInterface
      */
-    protected $currentTranslation;
+    private TranslationInterface $currentTranslation;
+    private ?string $fallbackLocale;
 
     /**
-     * @var null|string
-     */
-    protected $fallbackLocale;
-
-    /**
-     * TranslatableTrait constructor.
      * @codeCoverageIgnore
      */
     public function __construct()
@@ -91,6 +77,7 @@ trait TranslatableTrait
                 return $fallbackTranslation; //@codeCoverageIgnore
             }
         }
+
         $translation = $this->createTranslation();
         $translation->setLocale($locale);
 
@@ -138,19 +125,12 @@ trait TranslatableTrait
         return $this->translations;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasTranslation(TranslationInterface $translation): bool
     {
-        return isset($this->translationsCache[$translation->getLocale()]) || $this->translations->containsKey(
-            $translation->getLocale()
-        );
+        return isset($this->translationsCache[$translation->getLocale()])
+               || $this->translations->containsKey($translation->getLocale());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function addTranslation(TranslationInterface $translation): void
     {
         if (!$this->hasTranslation($translation)) {
@@ -161,9 +141,6 @@ trait TranslatableTrait
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function removeTranslation(TranslationInterface $translation): void
     {
         if ($this->translations->removeElement($translation)) {
@@ -173,17 +150,11 @@ trait TranslatableTrait
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setCurrentLocale(?string $currentLocale): void
     {
         $this->currentLocale = $currentLocale;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function setFallbackLocale(?string $fallbackLocale): void
     {
         $this->fallbackLocale = $fallbackLocale;
@@ -191,8 +162,6 @@ trait TranslatableTrait
 
     /**
      * Create resource translation model.
-     *
-     * @return TranslationInterface
      */
     abstract protected function createTranslation(): TranslationInterface;
 }

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -63,6 +63,7 @@ trait TranslatableTrait
 
             return $translation;
         }
+
         if ($locale !== $this->fallbackLocale) {
             if (isset($this->translationsCache[$this->fallbackLocale])) {
                 return $this->translationsCache[$this->fallbackLocale];

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -113,12 +113,15 @@ trait TranslatableTrait
         foreach ($translations as $translation) {
             if ($translation->getLocale() === $locale) {
                 $this->removeTranslation($translation);
+
+                $translation->setTranslatable(null);
             }
         }
     }
 
     /**
      * {@inheritdoc}
+     * @return Collection<TranslationInterface>
      */
     public function getTranslations(): Collection
     {

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -51,7 +51,7 @@ trait TranslatableTrait
             throw LocaleNotSupported::unsupported();
         }
 
-        // Grab translation from Translatable objects' available Translations
+        // Attempt to grab Translation from Translatable object
         $translation = $this->matchTranslation($locale);
         if ($translation instanceof TranslationInterface) {
             return $translation;
@@ -63,7 +63,6 @@ trait TranslatableTrait
             return null;
         }
 
-        // Check and return fallback Translation from Translatable objects' cache or attempt fallback locale match
         return $this->matchTranslation($this->fallbackLocale);
     }
 

--- a/src/Model/TranslationInterface.php
+++ b/src/Model/TranslationInterface.php
@@ -9,23 +9,9 @@ namespace Locastic\ApiPlatformTranslationBundle\Model;
  */
 interface TranslationInterface
 {
-    /**
-     * @return TranslatableInterface
-     */
     public function getTranslatable(): ?TranslatableInterface;
-
-    /**
-     * @param TranslatableInterface $translatable
-     */
     public function setTranslatable(?TranslatableInterface $translatable): void;
 
-    /**
-     * @return null|string
-     */
-    public function getLocale(): ?string;
-
-    /**
-     * @param null|string $locale
-     */
-    public function setLocale(?string $locale): void;
+    public function getLocale(): string;
+    public function setLocale(string $locale): void;
 }

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -24,7 +24,7 @@ class Translator implements TranslatorInterface
      */
     public function trans($id, array $parameters = [], string $domain = null, string $locale = null): string
     {
-        if (!$locale) {
+        if ($locale === null) {
             $locale = $this->loadCurrentLocale();
         }
 
@@ -48,14 +48,6 @@ class Translator implements TranslatorInterface
         $preferredLanguage = $request->getPreferredLanguage();
 
         return empty($preferredLanguage) ? $this->defaultLocale : $preferredLanguage;
-    }
-
-    /**
-     * @codeCoverageIgnore
-     */
-    public function setLocale($locale = 'en'): void
-    {
-        $this->translator->setLocale($locale);
     }
 
     /**

--- a/src/Translation/Translator.php
+++ b/src/Translation/Translator.php
@@ -8,45 +8,21 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * Class Translator
- *
  * @package Locastic\ApiPlatformTranslationBundle\Translation
  */
 class Translator implements TranslatorInterface
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
-     * @var string
-     */
-    private $defaultLocale;
-
-    /**
-     * Translator constructor.
-     *
-     * @param TranslatorInterface $translator
-     * @param RequestStack $requestStack
-     * @param string $defaultLocale
-     */
-    public function __construct(TranslatorInterface $translator, RequestStack $requestStack, string $defaultLocale)
-    {
-        $this->translator = $translator;
-        $this->requestStack = $requestStack;
-        $this->defaultLocale = $defaultLocale;
+    public function __construct(
+        private TranslatorInterface $translator,
+        private RequestStack $requestStack,
+        private string $defaultLocale
+    ) {
     }
 
     /**
      * {@inheritdoc}
      */
-    public function trans($id, array $parameters = array(), string $domain = null, string $locale = null): string
+    public function trans($id, array $parameters = [], string $domain = null, string $locale = null): string
     {
         if (!$locale) {
             $locale = $this->loadCurrentLocale();
@@ -55,9 +31,6 @@ class Translator implements TranslatorInterface
         return $this->translator->trans($id, $parameters, $domain, $locale);
     }
 
-    /**
-     * @return string
-     */
     public function loadCurrentLocale(): string
     {
         $request = $this->requestStack->getCurrentRequest();
@@ -78,7 +51,6 @@ class Translator implements TranslatorInterface
     }
 
     /**
-     * {@inheritdoc}
      * @codeCoverageIgnore
      */
     public function setLocale($locale = 'en'): void

--- a/tests/ApiPlatformTranslationBundleTest.php
+++ b/tests/ApiPlatformTranslationBundleTest.php
@@ -2,14 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Locastic\ApiTranslationBundle\Tests;
+namespace Locastic\ApiPlatformTranslationBundle\Tests;
 
 use Locastic\ApiPlatformTranslationBundle\ApiPlatformTranslationBundle;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class ApiPlatformTranslationBundleTest
- *
  * @package UnitTests\TranslationBundle
  * @covers \Locastic\ApiPlatformTranslationBundle\ApiPlatformTranslationBundle
  */

--- a/tests/EventListener/AssignLocaleListenerTest.php
+++ b/tests/EventListener/AssignLocaleListenerTest.php
@@ -4,37 +4,27 @@ declare(strict_types=1);
 
 namespace Locastic\ApiPlatformTranslationBundle\Tests\EventListener;
 
-use Doctrine\Common\EventArgs;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Locastic\ApiPlatformTranslationBundle\EventListener\AssignLocaleListener;
-use Locastic\ApiPlatformTranslationBundle\Translation\Translator;
 use Locastic\ApiPlatformTranslationBundle\Tests\Fixtures\DummyNotTranslatable;
 use Locastic\ApiPlatformTranslationBundle\Tests\Fixtures\DummyTranslatable;
 use Locastic\ApiPlatformTranslationBundle\Tests\Fixtures\DummyTranslation;
+use Locastic\ApiPlatformTranslationBundle\Translation\Translator;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class AssignLocaleListenerTest
- *
  * @package Locastic\ApiPlatformTranslationBundle\Tests\EventListener
  */
 class AssignLocaleListenerTest extends TestCase
 {
-    /**
-     * @var Translator
-     */
-    private $translator;
-
-    /**
-     * @var string
-     */
-    private $defaultLocale;
+    private Translator|\PHPUnit\Framework\MockObject\MockObject $translator;
+    private string $defaultLocale;
 
     /**
      * @test postLoad
      * @dataProvider provideTranslatableObjects
      */
-    public function testPostLoad($object)
+    public function testPostLoad($object): void
     {
         $args = $this->createMock(LifecycleEventArgs::class);
         $this->getObjectInfo($args, $object);
@@ -48,7 +38,7 @@ class AssignLocaleListenerTest extends TestCase
      * @test postLoad
      * @dataProvider provideNonTranslatableObjects
      */
-    public function testPostLoadNonTranslatableObjects($object)
+    public function testPostLoadNonTranslatableObjects($object): void
     {
         $args = $this->createMock(LifecycleEventArgs::class);
         $this->getObjectInfo($args, $object);
@@ -61,7 +51,7 @@ class AssignLocaleListenerTest extends TestCase
      * @test postLoad
      * @dataProvider provideTranslatableObjects
      */
-    public function testPrePersist($object)
+    public function testPrePersist($object): void
     {
         $args = $this->createMock(LifecycleEventArgs::class);
         $this->getObjectInfo($args, $object);
@@ -75,7 +65,7 @@ class AssignLocaleListenerTest extends TestCase
      * @test postLoad
      * @dataProvider provideNonTranslatableObjects
      */
-    public function testPrePersistNonTranslatableObjects($object)
+    public function testPrePersistNonTranslatableObjects($object): void
     {
         $args = $this->createMock(LifecycleEventArgs::class);
         $this->getObjectInfo($args, $object);
@@ -88,7 +78,7 @@ class AssignLocaleListenerTest extends TestCase
      * @param $args
      * @param $object
      */
-    private function getObjectInfo($args, $object)
+    private function getObjectInfo($args, $object): void
     {
         $args
             ->expects($this->once())
@@ -96,7 +86,7 @@ class AssignLocaleListenerTest extends TestCase
             ->willReturn($object);
     }
 
-    private function loadCurrentLocale()
+    private function loadCurrentLocale(): void
     {
         $this->translator
             ->expects($this->once())
@@ -113,20 +103,14 @@ class AssignLocaleListenerTest extends TestCase
         $this->defaultLocale = 'en';
     }
 
-    /**
-     * @return \Generator
-     */
-    public function provideTranslatableObjects()
+    public function provideTranslatableObjects(): \Generator
     {
-        yield[new DummyTranslatable()];
+        yield [new DummyTranslatable()];
     }
 
-    /**
-     * @return \Generator
-     */
-    public function provideNonTranslatableObjects()
+    public function provideNonTranslatableObjects(): \Generator
     {
-        yield[new DummyNotTranslatable()];
-        yield[new DummyTranslation()];
+        yield [new DummyNotTranslatable()];
+        yield [new DummyTranslation('en', null)];
     }
 }

--- a/tests/Fixtures/DummyNotTranslatable.php
+++ b/tests/Fixtures/DummyNotTranslatable.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Locastic\ApiPlatformTranslationBundle\Tests\Fixtures;
 
 /**
- * Class DummyNotTranslatable
- *
  * @package Locastic\ApiTranslationBundle\Tests\Fixtures
  */
 class DummyNotTranslatable

--- a/tests/Fixtures/DummyTranslatable.php
+++ b/tests/Fixtures/DummyTranslatable.php
@@ -8,8 +8,6 @@ use Locastic\ApiPlatformTranslationBundle\Model\AbstractTranslatable;
 use Locastic\ApiPlatformTranslationBundle\Model\TranslationInterface;
 
 /**
- * Class DummyTranslatable
- *
  * @package Locastic\ApiPlatformTranslationBundle\Tests\Fixtures
  */
 class DummyTranslatable extends AbstractTranslatable
@@ -19,6 +17,6 @@ class DummyTranslatable extends AbstractTranslatable
      */
     protected function createTranslation(): TranslationInterface
     {
-        return new DummyTranslation();
+        return new DummyTranslation('en', null);
     }
 }

--- a/tests/Fixtures/DummyTranslatable.php
+++ b/tests/Fixtures/DummyTranslatable.php
@@ -5,18 +5,10 @@ declare(strict_types=1);
 namespace Locastic\ApiPlatformTranslationBundle\Tests\Fixtures;
 
 use Locastic\ApiPlatformTranslationBundle\Model\AbstractTranslatable;
-use Locastic\ApiPlatformTranslationBundle\Model\TranslationInterface;
 
 /**
  * @package Locastic\ApiPlatformTranslationBundle\Tests\Fixtures
  */
 class DummyTranslatable extends AbstractTranslatable
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function createTranslation(): TranslationInterface
-    {
-        return new DummyTranslation('en', null);
-    }
 }

--- a/tests/Fixtures/DummyTranslation.php
+++ b/tests/Fixtures/DummyTranslation.php
@@ -13,7 +13,7 @@ use Locastic\ApiPlatformTranslationBundle\Model\TranslatableInterface;
 class DummyTranslation extends AbstractTranslation
 {
     public function __construct(
-        ?string $locale = null,
+        string $locale,
         ?TranslatableInterface $translatable = null,
         private ?string $translation = null
     ) {

--- a/tests/Fixtures/DummyTranslation.php
+++ b/tests/Fixtures/DummyTranslation.php
@@ -5,26 +5,21 @@ declare(strict_types=1);
 namespace Locastic\ApiPlatformTranslationBundle\Tests\Fixtures;
 
 use Locastic\ApiPlatformTranslationBundle\Model\AbstractTranslation;
+use Locastic\ApiPlatformTranslationBundle\Model\TranslatableInterface;
 
 /**
- * Class DummyTranslation
- *
  * @package Locastic\ApiPlatformTranslationBundle\Tests\Fixtures
  */
 class DummyTranslation extends AbstractTranslation
 {
-    /**
-     * @var null|string
-     */
-    private $translation;
+    public function __construct(
+        ?string $locale = null,
+        ?TranslatableInterface $translatable = null,
+        private ?string $translation = null
+    ) {
+        parent::__construct($locale, $translatable);
+    }
 
-    /**
-     * Set translation
-     *
-     * @param string $translation
-     *
-     * @return DummyTranslation
-     */
     public function setTranslation(string $translation): DummyTranslation
     {
         $this->translation = $translation;
@@ -32,11 +27,6 @@ class DummyTranslation extends AbstractTranslation
         return $this;
     }
 
-    /**
-     * Get translation
-     *
-     * @return null|string
-     */
     public function getTranslation(): ?string
     {
         return $this->translation;

--- a/tests/Model/AbstractTranslationTest.php
+++ b/tests/Model/AbstractTranslationTest.php
@@ -43,13 +43,11 @@ class AbstractTranslationTest extends TestCase
     /**
      * @test setTranslatable
      */
-    public function testGetFallbackTranslationWithoutLocaleParameter(): void
+    public function testGetNullWithoutLocaleParameter(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
 
-        $dummyTranslationEnglish = $this->setTranslation('en', 'english', $dummyTranslatable);
-
-        $this->assertSame($dummyTranslationEnglish, $dummyTranslatable->getTranslation());
+        $this->assertNull($dummyTranslatable->getTranslation());
     }
 
     /**

--- a/tests/Model/AbstractTranslationTest.php
+++ b/tests/Model/AbstractTranslationTest.php
@@ -18,7 +18,7 @@ class AbstractTranslationTest extends TestCase
     /**
      * @test setTranslatable
      */
-    public function testSetTranslatable()
+    public function testSetTranslatable(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslationEspanol = $this->setTranslation('es', 'espanol', $dummyTranslatable);
@@ -31,7 +31,7 @@ class AbstractTranslationTest extends TestCase
     /**
      * @test setTranslatable
      */
-    public function testGetCurrentTranslationWithoutLocaleParameter()
+    public function testGetCurrentTranslationWithoutLocaleParameter(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslationEspanol = $this->setTranslation('es', 'espanol', $dummyTranslatable);
@@ -43,7 +43,7 @@ class AbstractTranslationTest extends TestCase
     /**
      * @test setTranslatable
      */
-    public function testGetFallbackTranslationWithoutLocaleParameter()
+    public function testGetFallbackTranslationWithoutLocaleParameter(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
 
@@ -55,7 +55,7 @@ class AbstractTranslationTest extends TestCase
     /**
      * @test setTranslatable
      */
-    public function testChangeTranslation()
+    public function testChangeTranslation(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
 
@@ -66,15 +66,12 @@ class AbstractTranslationTest extends TestCase
         $this->assertSame('english2', $dummyTranslatable->getTranslation('en')->getTranslation());
     }
 
-    /**
-     * @param $locale
-     * @param $translation
-     * @param TranslatableInterface $translatable
-     * @return DummyTranslation
-     */
-    private function setTranslation($locale, $translation, TranslatableInterface $translatable)
-    {
-        $dummyTranslation = new DummyTranslation();
+    private function setTranslation(
+        string $locale,
+        string $translation,
+        TranslatableInterface $translatable
+    ): DummyTranslation {
+        $dummyTranslation = new DummyTranslation('en', null);
         $dummyTranslation->setLocale($locale);
         $dummyTranslation->setTranslation($translation);
         $dummyTranslation->setTranslatable($translatable);
@@ -82,12 +79,7 @@ class AbstractTranslationTest extends TestCase
         return $dummyTranslation;
     }
 
-    /**
-     * @param $currentLocale
-     * @param $fallbackLocale
-     * @return DummyTranslatable
-     */
-    private function setTranslatable($currentLocale, $fallbackLocale)
+    private function setTranslatable(string $currentLocale, string $fallbackLocale): DummyTranslatable
     {
         $dummyTranslatable = new DummyTranslatable();
         $dummyTranslatable->setCurrentLocale($currentLocale);

--- a/tests/Model/TranslatableTraitTest.php
+++ b/tests/Model/TranslatableTraitTest.php
@@ -18,7 +18,7 @@ class TranslatableTraitTest extends TestCase
     /**
      * @test getTranslationLocales
      */
-    public function testGetTranslationLocales()
+    public function testGetTranslationLocales(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $this->setTranslation('es', 'espanol', $dummyTranslatable);
@@ -30,7 +30,7 @@ class TranslatableTraitTest extends TestCase
     /**
      * @test getTranslation
      */
-    public function testGetTranslationFromTranslationsCache()
+    public function testGetTranslationFromTranslationsCache(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslatable->addTranslation($this->setTranslation('en', 'english', $dummyTranslatable));
@@ -40,7 +40,7 @@ class TranslatableTraitTest extends TestCase
     /**
      * @test getTranslation
      */
-    public function testGetTranslationWithoutFallbackLocale()
+    public function testGetTranslationWithoutFallbackLocale(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $this->assertEquals(null, $dummyTranslatable->getTranslation('it')->getTranslation());
@@ -49,7 +49,7 @@ class TranslatableTraitTest extends TestCase
     /**
      * @test getTranslation
      */
-    public function testGetTranslationWithFallbackTranslation()
+    public function testGetTranslationWithFallbackTranslation(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslatable->addTranslation($this->setTranslation('en', 'english', $dummyTranslatable));
@@ -59,7 +59,7 @@ class TranslatableTraitTest extends TestCase
     /**
      * @test getTranslation
      */
-    public function testRemoveTranslation()
+    public function testRemoveTranslation(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslationEnglish = $this->setTranslation('en', 'english', $dummyTranslatable);
@@ -71,7 +71,7 @@ class TranslatableTraitTest extends TestCase
     /**
      * @test getTranslation
      */
-    public function testGetTranslationWithoutLocales()
+    public function testGetTranslationWithoutLocales(): void
     {
         $dummyTranslatable = $this->setTranslatable(null, null);
 
@@ -79,18 +79,10 @@ class TranslatableTraitTest extends TestCase
         $dummyTranslatable->getTranslation();
     }
 
-    /**
-     * @param $locale
-     * @param $translation
-     * @param TranslatableInterface $translatable
-     * @return DummyTranslation
-     */
-    private function setTranslation($locale, $translation, TranslatableInterface $translatable)
+    private function setTranslation(string $locale, string $translation, TranslatableInterface $translatable): DummyTranslation
     {
-        $dummyTranslation = new DummyTranslation();
-        $dummyTranslation->setLocale($locale);
+        $dummyTranslation = new DummyTranslation($locale, $translatable);
         $dummyTranslation->setTranslation($translation);
-        $dummyTranslation->setTranslatable($translatable);
 
         return $dummyTranslation;
     }
@@ -100,7 +92,7 @@ class TranslatableTraitTest extends TestCase
      * @param $fallbackLocale
      * @return DummyTranslatable
      */
-    private function setTranslatable($currentLocale, $fallbackLocale)
+    private function setTranslatable($currentLocale, $fallbackLocale): DummyTranslatable
     {
         $dummyTranslatable = new DummyTranslatable();
         $dummyTranslatable->setCurrentLocale($currentLocale);

--- a/tests/Model/TranslatableTraitTest.php
+++ b/tests/Model/TranslatableTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Locastic\ApiPlatformTranslationBundle\Tests\Model;
 
+use Locastic\ApiPlatformTranslationBundle\Model\LocaleNotSupported;
 use Locastic\ApiPlatformTranslationBundle\Model\TranslatableInterface;
 use Locastic\ApiPlatformTranslationBundle\Tests\Fixtures\DummyTranslatable;
 use Locastic\ApiPlatformTranslationBundle\Tests\Fixtures\DummyTranslation;
@@ -68,6 +69,12 @@ class TranslatableTraitTest extends TestCase
         $this->assertEquals(null, $dummyTranslatable->getTranslation('en')?->getTranslation());
     }
 
+    public function testGetNullWithUnsupportedLocale(): void
+    {
+        $dummyTranslatable = $this->setTranslatable('es', 'en');
+        $this->assertNull($dummyTranslatable->getTranslation('unsupported'));
+    }
+
     /**
      * @test getTranslation
      */
@@ -75,7 +82,7 @@ class TranslatableTraitTest extends TestCase
     {
         $dummyTranslatable = $this->setTranslatable();
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(LocaleNotSupported::class);
         $dummyTranslatable->getTranslation();
     }
 

--- a/tests/Model/TranslatableTraitTest.php
+++ b/tests/Model/TranslatableTraitTest.php
@@ -34,7 +34,7 @@ class TranslatableTraitTest extends TestCase
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslatable->addTranslation($this->setTranslation('en', 'english', $dummyTranslatable));
-        $this->assertEquals('english', $dummyTranslatable->getTranslation('en')->getTranslation());
+        $this->assertEquals('english', $dummyTranslatable->getTranslation('en')?->getTranslation());
     }
 
     /**
@@ -43,7 +43,7 @@ class TranslatableTraitTest extends TestCase
     public function testGetTranslationWithoutFallbackLocale(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
-        $this->assertEquals(null, $dummyTranslatable->getTranslation('it')->getTranslation());
+        $this->assertEquals(null, $dummyTranslatable->getTranslation('it')?->getTranslation());
     }
 
     /**
@@ -53,7 +53,7 @@ class TranslatableTraitTest extends TestCase
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
         $dummyTranslatable->addTranslation($this->setTranslation('en', 'english', $dummyTranslatable));
-        $this->assertEquals('english', $dummyTranslatable->getTranslation('it')->getTranslation());
+        $this->assertEquals('english', $dummyTranslatable->getTranslation('it')?->getTranslation());
     }
 
     /**
@@ -65,7 +65,7 @@ class TranslatableTraitTest extends TestCase
         $dummyTranslationEnglish = $this->setTranslation('en', 'english', $dummyTranslatable);
 
         $dummyTranslatable->removeTranslation($dummyTranslationEnglish);
-        $this->assertEquals(null, $dummyTranslatable->getTranslation('en')->getTranslation());
+        $this->assertEquals(null, $dummyTranslatable->getTranslation('en')?->getTranslation());
     }
 
     /**
@@ -73,7 +73,7 @@ class TranslatableTraitTest extends TestCase
      */
     public function testGetTranslationWithoutLocales(): void
     {
-        $dummyTranslatable = $this->setTranslatable(null, null);
+        $dummyTranslatable = $this->setTranslatable();
 
         $this->expectException(\RuntimeException::class);
         $dummyTranslatable->getTranslation();
@@ -87,12 +87,7 @@ class TranslatableTraitTest extends TestCase
         return $dummyTranslation;
     }
 
-    /**
-     * @param $currentLocale
-     * @param $fallbackLocale
-     * @return DummyTranslatable
-     */
-    private function setTranslatable($currentLocale, $fallbackLocale): DummyTranslatable
+    private function setTranslatable(string $currentLocale = null, string $fallbackLocale = null): DummyTranslatable
     {
         $dummyTranslatable = new DummyTranslatable();
         $dummyTranslatable->setCurrentLocale($currentLocale);

--- a/tests/Translation/TranslatorTest.php
+++ b/tests/Translation/TranslatorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Locastic\ApiTranslationBundle\Tests\Translation;
+namespace Locastic\ApiPlatformTranslationBundle\Tests\Translation;
 
 use Locastic\ApiPlatformTranslationBundle\Translation\Translator;
 use PHPUnit\Framework\TestCase;
@@ -12,27 +12,14 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
- * Class TranslatorTest
- *
  * @package UnitTests\TranslationBundle\Translation
  * @covers \Locastic\ApiPlatformTranslationBundle\Translation\Translator
  */
 class TranslatorTest extends TestCase
 {
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var RequestStack
-     */
-    private $requestStack;
-
-    /**
-     * @var string
-     */
-    private $defaultLocale;
+    private TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject $translator;
+    private \PHPUnit\Framework\MockObject\MockObject|RequestStack $requestStack;
+    private string $defaultLocale;
 
     /**
      * {@inheritdoc}
@@ -54,7 +41,7 @@ class TranslatorTest extends TestCase
         $domain,
         $locale,
         $translation
-    ) {
+    ): void {
         $translator = new Translator($this->translator, $this->requestStack, $this->defaultLocale);
 
         $this->translator
@@ -76,7 +63,7 @@ class TranslatorTest extends TestCase
         $parameters,
         $domain,
         $translation
-    ) {
+    ): void {
         $translator = new Translator($this->translator, $this->requestStack, $this->defaultLocale);
 
         $this->translator
@@ -96,7 +83,7 @@ class TranslatorTest extends TestCase
     public function testLoadCurrentLocale(
         $requestedLocale,
         $expectedLocale
-    ) {
+    ): void {
         $translator = new Translator($this->translator, $this->requestStack, $this->defaultLocale);
 
         $request = $this->createMock(Request::class);
@@ -124,7 +111,7 @@ class TranslatorTest extends TestCase
         $requestedLocale,
         $acceptedLanguage,
         $expectedLocale
-    ) {
+    ): void {
         $translator = new Translator($this->translator, $this->requestStack, $this->defaultLocale);
 
         $request = $this->createConfiguredMock(Request::class, [
@@ -149,7 +136,7 @@ class TranslatorTest extends TestCase
     /**
      * @test loadCurrentLocale
      */
-    public function testLoadCurrentLocaleWithNoRequest()
+    public function testLoadCurrentLocaleWithNoRequest(): void
     {
         $translator = new Translator($this->translator, $this->requestStack, $this->defaultLocale);
 
@@ -164,10 +151,7 @@ class TranslatorTest extends TestCase
         $this->assertSame('en', $actualLocale);
     }
 
-    /**
-     * @return \Generator
-     */
-    public function provideTranslations()
+    public function provideTranslations(): \Generator
     {
         yield['hello_world', [], 'messages', 'en', 'Hello world!'];
         yield['hello_world', [], 'messages', 'hr', 'Dobar dan svijete!'];
@@ -181,19 +165,13 @@ class TranslatorTest extends TestCase
         yield['dateMessage', [], 'validators', 'en', 'This value is not a valid date.'];
     }
 
-    /**
-     * @return \Generator
-     */
-    public function provideTranslationsNoLocale()
+    public function provideTranslationsNoLocale(): \Generator
     {
         yield['hello_world', [], 'messages', 'Hello world!'];
         yield['dateMessage', [], 'validators', 'This value is not a valid date.'];
     }
 
-    /**
-     * @return \Generator
-     */
-    public function provideLocales()
+    public function provideLocales(): \Generator
     {
         yield['en', 'en'];
         yield['hr', 'hr'];
@@ -201,10 +179,7 @@ class TranslatorTest extends TestCase
         yield[null, 'en'];
     }
 
-    /**
-     * @return \Generator
-     */
-    public function provideLocalesWithAcceptLanguage()
+    public function provideLocalesWithAcceptLanguage(): \Generator
     {
         yield['en', 'fr', 'en'];
         yield['hr', 'de', 'hr'];


### PR DESCRIPTION
Noticed that when doing a `getTranslation` call it would create a default Translation instance if no translation was available at the time of the get call. 

As these are 2 separate commands (get vs create) decided to create a branch to remove the default creation of non-existent translations. 

This PR is on top of PR https://github.com/Locastic/ApiPlatformTranslationBundle/pull/49. 