### PR TITLE
Handle doctrine/collection:^2

### DIFF
--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -145,7 +145,7 @@ trait TranslatableTrait
     public function hasTranslation(TranslationInterface $translation): bool
     {
         return isset($this->translationsCache[$translation->getLocale()])
-               || $this->translations->containsKey($translation->getLocale());
+               || (null !== $translation->getLocale() && $this->translations->containsKey($translation->getLocale()));
     }
 
     /**


### PR DESCRIPTION
Doctrine interface ReadableCollection::containsKey only accepts string|int as key in doctrine/collection v2.

This PR add a check to locale before calling the containsKey method.