### PR TITLE
Handle null locales

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,10 +9,13 @@ on:
 jobs:
   symfony-tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: [ '8.0', '8.1', '8.2' ]
     steps:
     - uses: shivammathur/setup-php@v2
       with:
-        php-version: '8.0'
+        php-version: ${{ matrix.php-versions }}
     - uses: actions/checkout@v2
     - name: Copy .env.test.local
       run: php -r "file_exists('.env.test.local') || copy('.env.test', '.env.test.local');"
@@ -21,7 +24,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: vendor
-        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
         restore-keys: |
           ${{ runner.os }}-php-
     - name: Install Dependencies

--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -144,8 +144,11 @@ trait TranslatableTrait
      */
     public function hasTranslation(TranslationInterface $translation): bool
     {
-        return isset($this->translationsCache[$translation->getLocale()])
-               || (null !== $translation->getLocale() && $this->translations->containsKey($translation->getLocale()));
+        return null !== $translation->getLocale()
+            && (
+                isset($this->translationsCache[$translation->getLocale()])
+                || $this->translations->containsKey($translation->getLocale())
+            );
     }
 
     /**
@@ -155,7 +158,7 @@ trait TranslatableTrait
      */
     public function addTranslation(TranslationInterface $translation): void
     {
-        if (!$this->hasTranslation($translation)) {
+        if (!$this->hasTranslation($translation) && null !== $translation->getLocale()) {
             $this->translationsCache[$translation->getLocale()] = $translation;
 
             $this->translations->set($translation->getLocale(), $translation);
@@ -170,7 +173,7 @@ trait TranslatableTrait
      */
     public function removeTranslation(TranslationInterface $translation): void
     {
-        if ($this->translations->removeElement($translation)) {
+        if ($this->translations->removeElement($translation) && null !== $translation->getLocale()) {
             unset($this->translationsCache[$translation->getLocale()]);
 
             $translation->setTranslatable(null);

--- a/tests/Model/TranslatableTraitTest.php
+++ b/tests/Model/TranslatableTraitTest.php
@@ -18,6 +18,17 @@ class TranslatableTraitTest extends TestCase
     /**
      * @test getTranslationLocales
      */
+    public function testSetTranslatable(): void
+    {
+        $dummyTranslatable = $this->setTranslatable('es', 'en');
+        $this->setTranslation(null, 'no locale', $dummyTranslatable);
+
+        $this->assertEquals([], $dummyTranslatable->getTranslationLocales());
+    }
+
+    /**
+     * @test getTranslationLocales
+     */
     public function testGetTranslationLocales(): void
     {
         $dummyTranslatable = $this->setTranslatable('es', 'en');
@@ -79,7 +90,7 @@ class TranslatableTraitTest extends TestCase
         $dummyTranslatable->getTranslation();
     }
 
-    private function setTranslation(string $locale, string $translation, TranslatableInterface $translatable): DummyTranslation
+    private function setTranslation(?string $locale, string $translation, TranslatableInterface $translatable): DummyTranslation
     {
         $dummyTranslation = new DummyTranslation();
         $dummyTranslation->setLocale($locale);


### PR DESCRIPTION
This PR allow the handling of `null` locale in translation without bug on doctrine/collection^2 by skipping the add.

For me, next major version should not allow `null` locale in the core.


Another solution could be to treat `null` locale as same as the default one.