### PR TITLE
Initialize proxy objects if necessary

### DIFF
--- a/src/Model/TranslatableTrait.php
+++ b/src/Model/TranslatableTrait.php
@@ -8,6 +8,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\Comparison;
+use Doctrine\Persistence\Proxy;
 
 /**
  * @see TranslatableInterface
@@ -50,6 +51,10 @@ trait TranslatableTrait
      */
     public function getTranslation(?string $locale = null): TranslationInterface
     {
+        if ($this instanceof Proxy && !$this->__isInitialized()) {
+            $this->__load();
+        }
+
         $locale = $locale ?: $this->currentLocale;
         if (null === $locale) {
             throw new \RuntimeException('No locale has been set and current locale is undefined.');


### PR DESCRIPTION
In some cases, where no property of a lazy-loaded entity is accessed before trying to access/serialize the translations, the bundle will fail with the following error message:
```No locale has been set and current locale is undefined.```

The issue is that the `AssignLocaleListener` is not called if an entity is never actually loaded from the database, but only referenced through a doctrine proxy object.

A dirty workaround is to access a property before fetching the translations, so instead of doing
```
    public function getTitle(): string
    {
        return $this->getTranslation()->getTitle();
    }
```

We can do the following:
```
    public function getTitle(): string
    {
        $this->getName(); // Access non-translated property to initialize the proxy and trigger the AssignLocaleListener
        return $this->getTranslation()->getTitle();
    }
```

Obviously that's not a great workaround. This PR ensures that the proxies are properly initialized by doctrine before trying to load the translations instead by checking if an entity is a non-initialized proxy and, if it is, initialize it first.