### PR TITLE
chore(composer): widen dependency ranges and alias master as 2.0-dev

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -7,33 +7,29 @@ on:
     branches: [ master ]
 
 jobs:
-  symfony-tests:
+  tests:
     runs-on: ubuntu-latest
+    name: PHP ${{ matrix.php-versions }} ${{ matrix.dependencies }}
     strategy:
+      fail-fast: false
       matrix:
-        php-versions: ['8.4', '8.5']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        dependencies: ['highest']
+        include:
+          - php-versions: '8.2'
+            dependencies: 'lowest'
     steps:
+    - uses: actions/checkout@v4
     - uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ matrix.php-versions }}
-    - uses: actions/checkout@v4
-    - name: Copy .env.test.local
-      run: php -r "file_exists('.env.test.local') || copy('.env.test', '.env.test.local');"
-    - name: Cache Composer packages
-      id: composer-cache
-      uses: actions/cache@v4
-      with:
-        path: vendor
-        key: ${{ runner.os }}-php-${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-php-
-    - name: Install Dependencies
-      run: composer install --no-interaction --prefer-dist
-    - name: Create Database
-      run: |
-        mkdir -p data
-        touch data/database.sqlite
-    - name: Execute tests (Unit and Feature tests) via PHPUnit
-      env:
-        DATABASE_URL: sqlite:///%kernel.project_dir%/data/database.sqlite
-      run: vendor/phpunit/phpunit/phpunit
+    - name: Install dependencies (highest)
+      if: matrix.dependencies == 'highest'
+      run: composer update --no-interaction --prefer-dist
+    - name: Install dependencies (lowest)
+      if: matrix.dependencies == 'lowest'
+      run: composer update --no-interaction --prefer-dist --prefer-lowest --prefer-stable
+    - name: Validate composer.json
+      run: composer validate --strict
+    - name: Run tests
+      run: bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     }
   ],
   "require": {
-    "php": ">=8.4",
-    "api-platform/symfony": "^4.2",
-    "doctrine/orm": "^3.5",
-    "doctrine/doctrine-bundle": "^3.1",
-    "symfony/translation": "*",
-    "symfony/dependency-injection": "*"
+    "php": "^8.2",
+    "api-platform/symfony": "^3.4 || ^4.0",
+    "doctrine/orm": "^3.0",
+    "doctrine/doctrine-bundle": "^2.13 || ^3.0",
+    "symfony/translation": "^6.4 || ^7.0 || ^8.0",
+    "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^10.5"
@@ -33,13 +33,10 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "1.0-dev"
+      "dev-master": "2.0-dev"
     }
   },
   "config": {
     "bin-dir": "bin"
-  },
-  "conflict": {
-    "symfony/translations-contracts": "<2.0"
   }
 }


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Issues        | relates to #73
| License       | MIT

## Problem

v1.4.1 narrowed the requirements to PHP >= 8.4 and API Platform ^4.2 in a patch release, stranding API Platform 3 and PHP 8.2/8.3 users on v1.4 although nothing in the code requires the newer platforms. The symfony/* constraints were unbound wildcards, the branch alias still said 1.0-dev, and the conflict rule targeted a misspelled package name (`symfony/translations-contracts`), so it never had any effect.

## Changes

- Widen requirements: `php ^8.2`, `api-platform/symfony ^3.4 || ^4.0`, `doctrine/orm ^3.0`, `doctrine/doctrine-bundle ^2.13 || ^3.0`, and real ranges (`^6.4 || ^7.0 || ^8.0`) for `symfony/translation` and `symfony/dependency-injection` instead of `*`.
- Alias `dev-master` as `2.0-dev`: the next release will be tagged v2.0.0.
- Remove the dead `conflict` entry (misspelled package name, and the new symfony/translation floor makes it redundant anyway).
- CI: expand the matrix to PHP 8.2-8.5, add a lowest-deps leg, add `composer validate --strict`, and drop the vestigial `.env.test`/sqlite steps (the suite is pure unit tests and needs neither).

## Verification

Locally on PHP 8.4: `composer update --prefer-lowest --prefer-stable` resolves to api-platform/symfony 3.4.0, symfony 6.4, doctrine/orm 3.0.0, doctrine-bundle 2.13.0 and the suite passes 45/45; highest deps resolve to api-platform/symfony 4.3.15, symfony 8.1.1, orm 3.6.7, doctrine-bundle 3.2.4, also 45/45. `composer validate --strict` is clean.
