### PR TITLE
docs: add changelog, contributing guide, security policy, and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Something is broken
+labels: bug
+---
+
+| Q                  | A
+|--------------------|---
+| Bundle version     | x.y.z
+| API Platform       | x.y.z
+| Symfony            | x.y.z
+| PHP                | x.y.z
+
+## Description
+
+<!-- What happens, and what did you expect instead? Include the full error message if there is one. -->
+
+## How to reproduce
+
+<!-- Minimal entity/config/request that triggers the problem. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Commercial support
+    url: https://locastic.com
+    about: Want help with this bundle or an API Platform/Symfony project? Contact info@locastic.com

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest an improvement
+labels: enhancement
+---
+
+## Problem
+
+<!-- What can't you do today, or what is awkward? -->
+
+## Proposed solution
+
+<!-- How you imagine it working (API, config, behavior). Alternatives you considered are welcome. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+| Q             | A
+|---------------|---
+| Bug fix?      | yes/no
+| New feature?  | yes/no
+| BC breaks?    | yes/no
+| Deprecations? | yes/no
+| Issues        | fixes #X, relates to #Y
+| License       | MIT
+
+<!--
+BC breaks include changes to public method signatures, service IDs, the
+"translations" serializer group, the "translation.groups" filter id, and
+?locale= behavior. Answering yes requires an UPGRADE-X.Y.md entry in this PR.
+Please also add a line to the Unreleased section of CHANGELOG.md.
+-->
+
+## Problem
+
+<!-- What is broken or missing? Include errors, failing commands, issue links. -->
+
+## Changes
+
+<!-- One bullet per logical change. -->
+
+## Verification
+
+<!-- Exactly what you ran and the result (commands, test counts, environment). -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+See [UPGRADE-2.0.md](UPGRADE-2.0.md) for upgrade instructions.
+
+### Changed
+- **BREAKING** Dependency floors: PHP `^8.2`, `api-platform/symfony ^3.4 || ^4.0`,
+  `doctrine/orm ^3.0`, `doctrine/doctrine-bundle ^2.13 || ^3.0`; real version
+  ranges for the symfony packages instead of wildcards (#76)
+- **BREAKING** `AssignLocaleListener` signatures moved from `Doctrine\Common\EventArgs`
+  to `Doctrine\Persistence\Event\LifecycleEventArgs` (#78)
+- **BREAKING** `Translator` implements `LocaleAwareInterface`, requires a
+  `TranslatorInterface&LocaleAwareInterface` wrapped translator, and declares
+  parameter types on `trans()` and `setLocale()` (#78)
+- When `framework.enabled_locales` is configured, requested locales outside the
+  list (query parameter or `Accept-Language`) fall back to the default locale (#71)
+- README rewritten with PHP attributes and current API Platform metadata (#77)
+
+### Added
+- PHPStan level 6 and php-cs-fixer, enforced in CI (#78)
+- CI matrix covering PHP 8.2 to 8.5 plus a lowest-dependencies leg (#76)
+
+## [1.4.1] - 2025-12-18
+
+### Changed
+- Support for API Platform 4 and Symfony 7.4 (#75). Note: this release also
+  raised the PHP floor to 8.4 and dropped API Platform 2/3 support; 2.0 restores
+  the wider ranges.
+
+## [1.4] - 2024-05-10
+
+### Added
+- Doctrine ORM 3 support (#68)
+
+Older releases are documented on the
+[releases page](https://github.com/Locastic/ApiPlatformTranslationBundle/releases).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+Thanks for considering a contribution. Bug reports, fixes, docs improvements,
+and features are all welcome.
+
+## Setup
+
+```bash
+git clone git@github.com:<your-fork>/ApiPlatformTranslationBundle.git
+cd ApiPlatformTranslationBundle
+composer install
+```
+
+PHP 8.2 or newer is required. Tools are installed to `bin/`.
+
+## Quality gates
+
+All four must pass before a pull request can be merged (CI enforces them):
+
+```bash
+bin/phpunit                  # test suite (pure unit tests, no services needed)
+bin/phpstan analyse          # static analysis, level 6, zero errors
+bin/php-cs-fixer fix         # code style (@Symfony + declare_strict_types)
+composer validate --strict
+```
+
+New logic ships with tests. Tests use `testCamelCase` naming and data providers.
+
+## Pull requests
+
+- Target `master`. Bug fixes may be backported to the latest `1.x` release
+  branch by the maintainers.
+- One logical change per PR; don't mix refactoring with features.
+- Fill in the PR template honestly, in particular the BC-breaks question:
+  public method signatures, service IDs, the `translations` serializer group,
+  the `translation.groups` filter id, and `?locale=` behavior are all public API.
+  A BC break requires an entry in the current `UPGRADE-X.Y.md` in the same PR.
+- Add a line to the Unreleased section of `CHANGELOG.md`.
+
+## Bugs and questions
+
+Open an issue using the templates. For security vulnerabilities do NOT open a
+public issue; see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported          |
+|---------|--------------------|
+| 2.x     | yes                |
+| 1.4.x   | security fixes     |
+| < 1.4   | no                 |
+
+## Reporting a vulnerability
+
+Please do NOT open a public issue for security problems. Report them privately
+to **info@locastic.com** and include the affected version, a description, and a
+proof of concept if possible. You will receive a response within a few days;
+please allow time for a fix and coordinated disclosure before publishing
+details.


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Issues        | -
| License       | MIT

## Problem

The repository has no CHANGELOG, CONTRIBUTING guide, security policy, or issue/PR templates, so contributors have no documented expectations and the 2.0 changes have no user-facing history beyond release notes.

## Changes

- `CHANGELOG.md` in Keep a Changelog format: the 2.0 changes (#71, #76, #77, #78) under Unreleased with BREAKING markers pointing at UPGRADE-2.0.md, brief 1.4.1/1.4 history, and a link to the releases page for older versions.
- `CONTRIBUTING.md`: setup, the four quality gates, and PR expectations (what counts as public API, UPGRADE and CHANGELOG duties).
- `SECURITY.md`: private reporting channel and a supported-versions table (2.x supported, 1.4.x security fixes only).
- Issue templates (bug report with a versions table, feature request), a contact link for commercial support, and a PR template with the Q/A table used by recent PRs.
