### PR TITLE
fix(serializer): leave IRI-referenced translations to native denormalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Translations referenced by IRI (translation exposed as its own `ApiResource`)
+  are again resolved by API Platform's native denormalization; 2.0.0
+  intercepted such payloads and silently dropped the references, removing every
+  existing translation on `PUT`
+
 ## [2.0.0] - 2026-07-07
 
 See [UPGRADE-2.0.md](UPGRADE-2.0.md) for upgrade instructions.

--- a/src/Serializer/TranslatableItemDenormalizer.php
+++ b/src/Serializer/TranslatableItemDenormalizer.php
@@ -14,6 +14,10 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 /**
  * Denormalizes the locale-keyed `translations` map of a translatable resource.
  *
+ * Applies only to the embedded shape (translation documents keyed by locale, or a list
+ * of documents carrying `locale`); payloads referencing translations by IRI are left to
+ * API Platform's native denormalization (see isEmbeddedTranslationsMap()).
+ *
  * Without this, API Platform denormalizes the map as plain objects with no identity,
  * so it recreates every row (ignoring `id`) and orphan-removes locales absent from the
  * payload. This denormalizer intercepts a translatable, handles the `translations` map
@@ -45,7 +49,8 @@ final class TranslatableItemDenormalizer implements DenormalizerInterface, Denor
             && isset($data['translations'])
             && \is_array($data['translations'])
             && is_a($type, TranslatableInterface::class, true)
-            && empty($context[self::ALREADY_CALLED]);
+            && empty($context[self::ALREADY_CALLED])
+            && $this->isEmbeddedTranslationsMap($data['translations']);
     }
 
     public function getSupportedTypes(?string $format): array
@@ -129,6 +134,27 @@ final class TranslatableItemDenormalizer implements DenormalizerInterface, Denor
         }
 
         return $translatable;
+    }
+
+    /**
+     * Only the embedded shape (every item a document, keyed by locale or carrying one)
+     * is this denormalizer's business. Translations referenced by IRI strings, when the
+     * translation is exposed as its own ApiResource, must go through API Platform's
+     * native denormalization so the IRIs resolve to the existing entities; intercepting
+     * them here would silently drop them (and, on PUT, remove every existing
+     * translation). Mixed shapes are ambiguous and take the native path too.
+     *
+     * @param array<array-key, mixed> $translations
+     */
+    private function isEmbeddedTranslationsMap(array $translations): bool
+    {
+        foreach ($translations as $translation) {
+            if (!\is_array($translation)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/tests/Serializer/TranslatableItemDenormalizerTest.php
+++ b/tests/Serializer/TranslatableItemDenormalizerTest.php
@@ -37,6 +37,24 @@ final class TranslatableItemDenormalizerTest extends TestCase
         ));
     }
 
+    public function testLeavesIriReferencedTranslationsToTheNativeDenormalizer(): void
+    {
+        // Translations referenced by IRI (translation exposed as its own ApiResource)
+        // are not the embedded locale-keyed shape this denormalizer handles. It must
+        // step aside so API Platform resolves the IRIs natively; intercepting would
+        // silently drop them (and, on PUT, remove every existing translation).
+        self::assertFalse($this->denormalizer->supportsDenormalization(
+            ['translations' => ['/api/dummy_translations/1', '/api/dummy_translations/2']],
+            DummyTranslatable::class,
+        ));
+
+        // Mixed shapes are ambiguous: hand the whole payload to the native path too.
+        self::assertFalse($this->denormalizer->supportsDenormalization(
+            ['translations' => ['/api/dummy_translations/1', 'en' => ['translation' => 'EN']]],
+            DummyTranslatable::class,
+        ));
+    }
+
     public function testPatchPopulatesExistingTranslationInPlaceAndKeepsAbsentLocales(): void
     {
         $translatable = $this->translatableWith(['en' => 'EN', 'de' => 'DE']);


### PR DESCRIPTION
| Q             | A
|---------------|---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Issues        | relates to #40
| License       | MIT

## Problem

`TranslatableItemDenormalizer` (new in 2.0.0) claims every payload whose `translations` key is an array, including a list of IRI strings, the shape used when translations are exposed as their own `ApiResource` (as in #40). It then skips the string items, so the references are silently dropped on `POST` and `PATCH`, and `PUT` removes every existing translation because no submitted locale is recorded. Before 2.0.0, API Platform resolved such IRIs natively.

## Changes

- Restrict `supportsDenormalization` to the embedded shape (every item a document): IRI lists and mixed payloads take the native denormalization path again, restoring the pre-2.0 behavior for that shape.
- Keep the in-loop skip of non-array items as defense for direct `denormalize()` calls.
- Unit test pinning the pass-through for IRI lists and mixed payloads; CHANGELOG entry under Unreleased.

## Verification

- New test fails on 2.0.0 (the denormalizer claims the IRI-list payload) and passes with the fix.
- `bin/phpunit`: 66 tests, 131 assertions, green (9 pre-existing deprecations).
- `bin/phpstan analyse --memory-limit=512M`: no errors (level 6).
- `bin/php-cs-fixer check`: no violations.
- `composer validate --strict`: valid.
